### PR TITLE
Changing karma config

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'Firefox'],
 
     plugins: [
       'karma-mocha',
@@ -59,6 +59,7 @@ module.exports = function(config) {
       'karma-dirty-chai',
       'karma-babel-preprocessor',
       'karma-chrome-launcher',
+      'karma-firefox-launcher',
       'karma-coverage',
       'karma-verbose-reporter'
     ],
@@ -69,6 +70,6 @@ module.exports = function(config) {
 
     // Concurrency level
     // how many browser should be started simultaneous
-    concurrency: Infinity,
+    concurrency: 2
   })
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'sinon-chai', 'dirty-chai'],
+    frameworks: ['mocha', 'chai', 'sinon', 'sinon-chai', 'dirty-chai'],
 
     // list of files / patterns to load in the browser
     files: [
@@ -70,11 +70,5 @@ module.exports = function(config) {
     // Concurrency level
     // how many browser should be started simultaneous
     concurrency: Infinity,
-
-    client: {
-      mocha: {
-        opts: true
-      }
-    }
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1517,6 +1517,12 @@
       "integrity": "sha1-xGjM+HG9KGQrHxR2nlKgmdEQQzw=",
       "dev": true
     },
+    "karma-firefox-launcher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.0.1.tgz",
+      "integrity": "sha1-zlj0fCATqIFW1VpdYTN8CZz1u1E=",
+      "dev": true
+    },
     "karma-mocha": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-dirty-chai": "^1.0.2",
+    "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-sinon": "^1.0.5",
     "karma-sinon-chai": "^1.3.1",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---colors
---require test/test.js

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --colors
---reporter progress
 --require test/test.js

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,0 @@
-import sinon from 'sinon';
-import chai from 'chai';
-const expect = chai.expect;
-import dirtyChai from 'dirty-chai';
-import sinonChai from 'sinon-chai';
-chai.use(dirtyChai).use(sinonChai);
-global.sinon = sinon;
-global.expect = expect;


### PR DESCRIPTION
Things done:
* Removal of mocha opts as we have two reporters within karma.
* Removal of test file as karma uses this through frameworks.
* Babel preprocessor left in because it is used via ["babel"] in the config to compile down code.
* Added firefox browser due to firefox and chrome being very popular and good idea to test in both environments.
* Changed concurrency to two, if we add more browsers to test against may be hard to see whats going on if have Infinity running at same time.


**Instructions**

1. Pull down branch
2. Do a ```npm i```
3. Run tests and ensure same output, change assertions etc make sure they work.
4. Make sure it states that the tests are being ran for chrome and firefox. Should load both browsers also.

**Comments**
Any questions comment on the line you have a question about.